### PR TITLE
Feat/favorite functionality

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,0 +1,15 @@
+const baseUrl = "https://throbbing-wood-3534.fly.dev/api/v1/business"
+
+const checkError = (response) => {
+  if (!response.ok) {
+    throw new Error(`${response.status}`);
+  }
+  return response.json();
+}
+
+const getBusiness = (type, location) => {
+  return fetch(`${baseUrl}?business=${type}&location=${location}`)
+    .then(response => checkError(response))
+}
+
+export { getBusiness };

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import { Route, Switch } from "react-router-dom";
 import { gql } from '@apollo/client';
+import { getBusiness } from '../../apiCalls.js';
 import Nav from "../Nav/Nav";
 import LandingPage from "../LandingPage/LandingPage";
 import Footer from "../Footer/Footer";
@@ -12,44 +13,30 @@ import './App.css';
 const App = ({client}) => {
   const [ location, setLocation ] = useState('');
   const [ business, setBusiness ] = useState('family restaurant');
-  // const [ featured, setFeatured ] = useState([]);
+  const [ featured, setFeatured ] = useState([]);
   const [ results, setResults ] = useState([]);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [user, setUser] = useState(null)
   
+  const genRandomNum = (min, max) => {
+    return Math.floor(Math.random() * (max - min + 1) + min)
+  }
 
-  // const genRandomNum = (min, max) => {
-  //   return Math.floor(Math.random() * (max - min + 1) + min)
-  // }
-
-  // useEffect(() => {
-  //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$restaurant&location=denver`)
-  //     .then(res => res.json())
-  //     .then(data => {
-  //       const featRes = data.data[genRandomNum(0, data.data.length)];
-  //       console.log('featRes', featRes)
-  //     });
-    
-  //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$market&location=denver`)
-  //     .then(res => res.json())
-  //     .then(data => {
-  //       const featMarket = data.data[genRandomNum(0, data.data.length)];
-  //       console.log('featMarket', featMarket)
-  //     });
-
-  //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$brewery&location=denver`)
-  //     .then(res => res.json())
-  //     .then(data => {
-  //       const featBrewery = data.data[genRandomNum(0, data.data.length)];
-  //       console.log('featBrewery', featBrewery)
-  //     });
-
-  //       // we would want to change the api end points to reflect what we're actually searching at business= query;
-  // }, [])
+  useEffect(() => {
+    Promise.all([getBusiness('family restaurant', 'denver'), getBusiness('farmers market', 'denver'), getBusiness('brewery', 'denver')])
+      .then(data => {
+          const randomFeatBusinesses = data.reduce((acc, business) => {
+          const featBusiness = business.data[genRandomNum(0, business.data.length)];
+          acc.push(featBusiness);
+          return acc;
+        }, []) 
+        setFeatured(randomFeatBusinesses);
+      })
+      .catch(error => console.log('promise.all error: ', error))
+  }, [])
 
   const onSearch = (business, searchQuery) => {
-    
     fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=${business}&location=${searchQuery}`)
       .then(res => {
         if (!res.ok) {
@@ -168,7 +155,12 @@ const App = ({client}) => {
       />
       <Switch>
         <Route exact path="/">
-          <LandingPage />
+          <LandingPage
+            featured={featured}
+            user={user}
+            addFavorite={addFavorite}
+            deleteFavorite={deleteFavorite}
+          />
         </Route>
         <Route exact path="/results">
          <ResultsPage 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -27,9 +27,9 @@ const App = ({client}) => {
     Promise.all([getBusiness('family restaurant', 'denver'), getBusiness('farmers market', 'denver'), getBusiness('brewery', 'denver')])
       .then(data => {
           const randomFeatBusinesses = data.reduce((acc, business) => {
-          const featBusiness = business.data[genRandomNum(0, business.data.length)];
-          acc.push(featBusiness);
-          return acc;
+            const featBusiness = business.data[genRandomNum(0, business.data.length - 1)];
+            acc.push(featBusiness);
+            return acc;
         }, []) 
         setFeatured(randomFeatBusinesses);
       })

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,9 +15,9 @@ const App = ({client}) => {
   const [ business, setBusiness ] = useState('family restaurant');
   const [ featured, setFeatured ] = useState([]);
   const [ results, setResults ] = useState([]);
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [user, setUser] = useState(null)
+  const [ name, setName ] = useState('');
+  const [ email, setEmail ] = useState('');
+  const [ user, setUser ] = useState(null);
   
   const genRandomNum = (min, max) => {
     return Math.floor(Math.random() * (max - min + 1) + min)
@@ -37,14 +37,7 @@ const App = ({client}) => {
   }, [])
 
   const onSearch = (business, searchQuery) => {
-    fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=${business}&location=${searchQuery}`)
-      .then(res => {
-        if (!res.ok) {
-          throw new Error('Oops, something went wrong trying to find businesses in your location. Try entering a different location!')
-        } else {
-          return res.json()
-        }
-      })
+    getBusiness(business, searchQuery)
       .then(data => setResults(data.data))
       .catch(error => console.log('onSearch fetch error: ', error))
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -109,6 +109,7 @@ const App = ({client}) => {
                }`
     })
     .then(res => console.log('addFavorite response: ', res))
+    .catch(error => console.log('addFavorite error: ', error))
   }
 
   const deleteFavorite = (id) => {
@@ -126,7 +127,7 @@ const App = ({client}) => {
               }`
     })
     .then(res => console.log('deleteFav response: ', res))
-    // when passing id, it must parseInt
+    .catch(error => console.log('deleteFav error: ', error))
   }
 
   console.log("I am user in app: ", user);
@@ -155,6 +156,17 @@ const App = ({client}) => {
             deleteFavorite={deleteFavorite}
           />
         </Route>
+        <Route exact path="/featured/:alias" render={({ match })=> {
+          const businessToRender = featured.find(business => business.attributes.alias === match.params.alias)
+          return <SingleResultPage 
+                    business={businessToRender}
+                    user={user}
+                    addFavorite={addFavorite}
+                    deleteFavorite={deleteFavorite}
+                 />
+          }
+         } 
+        />
         <Route exact path="/results">
          <ResultsPage 
           results={results}
@@ -180,6 +192,17 @@ const App = ({client}) => {
             deleteFavorite={deleteFavorite}
           />
         </Route>
+        <Route exact path="/favorites/:title" render={({ match })=> {
+          // const businessToRender = user.favorites.find(business => business.title === match.params.title)
+          // return <SingleResultPage 
+          //           business={businessToRender}
+          //           user={user}
+          //           addFavorite={addFavorite}
+          //           deleteFavorite={deleteFavorite}
+          //        />
+          }
+         } 
+        />
       </Switch>
       <Footer/>
     </main>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -108,7 +108,12 @@ const App = ({client}) => {
                  }
                }`
     })
-    .then(res => console.log('addFavorite response: ', res))
+    .then(res => {
+      console.log('addFavorite response: ', res);
+      // confused regarding having to refresh for new user data... tried this logic, not sure what's going on.
+      // const updatedUser = getUser(user.email);
+      // setUser(updatedUser);
+    })
     .catch(error => console.log('addFavorite error: ', error))
   }
 
@@ -193,6 +198,8 @@ const App = ({client}) => {
           />
         </Route>
         <Route exact path="/favorites/:title" render={({ match })=> {
+          // this is where we would mimic similar logic as the /results/:alias and /featured/:alias routes...
+          // however, there is no alias in favorites, and I don't know how to change the params variable hahaha
           // const businessToRender = user.favorites.find(business => business.title === match.params.title)
           // return <SingleResultPage 
           //           business={businessToRender}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Route, Switch } from "react-router-dom";
 import { gql } from '@apollo/client';
 import Nav from "../Nav/Nav";
@@ -25,11 +25,27 @@ const App = ({client}) => {
 
   // useEffect(() => {
   //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$restaurant&location=denver`)
-  //     .then(data => data.json())
-  //       // use random num gen and length of restaurants to find a random denv rest
-  //       // set a first element in featured array
-  //       // repeat this logic for brewery and grocery?
-  //       // could add random logic for other locations if we felt inclined
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       const featRes = data.data[genRandomNum(0, data.data.length)];
+  //       console.log('featRes', featRes)
+  //     });
+    
+  //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$market&location=denver`)
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       const featMarket = data.data[genRandomNum(0, data.data.length)];
+  //       console.log('featMarket', featMarket)
+  //     });
+
+  //   fetch(`https://throbbing-wood-3534.fly.dev/api/v1/business?business=$brewery&location=denver`)
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       const featBrewery = data.data[genRandomNum(0, data.data.length)];
+  //       console.log('featBrewery', featBrewery)
+  //     });
+
+  //       // we would want to change the api end points to reflect what we're actually searching at business= query;
   // }, [])
 
   const onSearch = (business, searchQuery) => {
@@ -93,7 +109,8 @@ const App = ({client}) => {
                    url: "${site}",
                    image: "${img}",
                    phone: "${display_phone}",
-                   userId: "${userID}"
+                   userId: "${userID}",
+                   isClosed: "currently required, but data is unused on the FE"
                  }) {
                   favorite {
                     id,
@@ -131,6 +148,8 @@ const App = ({client}) => {
     .then(res => console.log('deleteFav response: ', res))
     // when passing id, it must parseInt
   }
+
+  console.log("I am user in app: ", user);
 
   return (
     <main className="page-container">

--- a/src/components/FavoritesPage/FavoritesPage.js
+++ b/src/components/FavoritesPage/FavoritesPage.js
@@ -11,10 +11,9 @@ const FavoritesPage = ({ user }) => {
     favorites = "You should log in"
   } else if (user.favorites.length === 0) {
     favorites = "You dont have any favorites yet"
-  } else {
+  } else if (!searchFavorites) {
     favorites = user.favorites.map((favorite) => {
       const { id, title, rating, image, alias} = favorite;
-      console.log('this is a favorite: ', favorite)
       return (
         <ResultCard
           key={id}
@@ -24,6 +23,24 @@ const FavoritesPage = ({ user }) => {
           photo={image}
           alias={alias}
           user={user}
+          displayType="favorite"
+        />
+      )
+    })
+  } else {
+    const filteredFavorites = user.favorites.filter(favorite => favorite.title.toLowerCase().includes(searchFavorites.toLocaleLowerCase()));
+    favorites = filteredFavorites.map((favorite) => {
+      const { id, title, rating, image, alias} = favorite;
+      return (
+        <ResultCard
+          key={id}
+          id={id}
+          title={title}
+          rating={rating}
+          photo={image}
+          alias={alias}
+          user={user}
+          displayType="favorite"
         />
       )
     })
@@ -44,7 +61,7 @@ const FavoritesPage = ({ user }) => {
           value={searchFavorites} 
           onChange={(event) => setSearchFavorites(event.target.value)} 
           required/>
-        <button disabled={searchFavorites.length<1} type='submit' className='submit' onClick={(event) => handleClick(event)}>GO</button>
+        <button disabled={searchFavorites.length < 1} type='submit' className='submit' onClick={(event) => handleClick(event)}>GO</button>
       </form>}
       {favorites}
     </section>

--- a/src/components/FavoritesPage/FavoritesPage.js
+++ b/src/components/FavoritesPage/FavoritesPage.js
@@ -4,6 +4,7 @@ import ResultCard from '../ResultCard/ResultCard'
 
 const FavoritesPage = ({ user }) => {
   const [searchFavorites, setSearchFavorites] = useState('')
+  
   let favorites;
 
   if (!user) {
@@ -11,19 +12,18 @@ const FavoritesPage = ({ user }) => {
   } else if (user.favorites.length === 0) {
     favorites = "You dont have any favorites yet"
   } else {
-    favorites = user.favorites.map((business) => {
-      const { id, title, rating, img, is_closed, alias} = business
-      console.log(business)
+    favorites = user.favorites.map((favorite) => {
+      const { id, title, rating, img, alias} = favorite;
+      console.log('this is a favorite: ', favorite)
       return (
-      <ResultCard
-        key={id}
-        id={id}
-        title={title}
-        rating={rating}
-        photo={img}
-        isClosed={is_closed}
-        alias={alias}
-      />
+        <ResultCard
+          key={id}
+          id={id}
+          title={title}
+          rating={rating}
+          photo={img}
+          alias={alias}
+        />
       )
     })
   }

--- a/src/components/FavoritesPage/FavoritesPage.js
+++ b/src/components/FavoritesPage/FavoritesPage.js
@@ -2,9 +2,15 @@ import {useState} from 'react'
 import "./FavoritesPage.css"
 import ResultCard from '../ResultCard/ResultCard'
 
-const FavoritesPage = ({ user }) => {
+const FavoritesPage = ({ user, deleteFavorite }) => {
   const [searchFavorites, setSearchFavorites] = useState('')
   
+  let displaySearch = false;
+
+  if (user && user.favorites.length > 0) {
+    displaySearch = true;
+  }
+
   let favorites;
 
   if (!user) {
@@ -23,6 +29,7 @@ const FavoritesPage = ({ user }) => {
           photo={image}
           alias={alias}
           user={user}
+          deleteFavorite={deleteFavorite}
           displayType="favorite"
         />
       )
@@ -50,18 +57,16 @@ const FavoritesPage = ({ user }) => {
     event.preventDefault()
   }
 
-
-
   return (
     <section className="favorites-section">
-      {user && <form className='keyword-form'>
+      {displaySearch && <form className='keyword-form'>
         <input type='text' 
           placeholder='SEARCH FAVORITES' 
           className='input' 
           value={searchFavorites} 
           onChange={(event) => setSearchFavorites(event.target.value)} 
           required/>
-        <button disabled={searchFavorites.length < 1} type='submit' className='submit' onClick={(event) => handleClick(event)}>GO</button>
+        {/* <button disabled={searchFavorites.length < 1} type='submit' className='submit' onClick={(event) => handleClick(event)}>GO</button> */}
       </form>}
       {favorites}
     </section>

--- a/src/components/FavoritesPage/FavoritesPage.js
+++ b/src/components/FavoritesPage/FavoritesPage.js
@@ -53,10 +53,6 @@ const FavoritesPage = ({ user, deleteFavorite }) => {
     })
   }
 
-  const handleClick = (event) => {
-    event.preventDefault()
-  }
-
   return (
     <section className="favorites-section">
       {displaySearch && <form className='keyword-form'>
@@ -66,7 +62,6 @@ const FavoritesPage = ({ user, deleteFavorite }) => {
           value={searchFavorites} 
           onChange={(event) => setSearchFavorites(event.target.value)} 
           required/>
-        {/* <button disabled={searchFavorites.length < 1} type='submit' className='submit' onClick={(event) => handleClick(event)}>GO</button> */}
       </form>}
       {favorites}
     </section>

--- a/src/components/FavoritesPage/FavoritesPage.js
+++ b/src/components/FavoritesPage/FavoritesPage.js
@@ -13,7 +13,7 @@ const FavoritesPage = ({ user }) => {
     favorites = "You dont have any favorites yet"
   } else {
     favorites = user.favorites.map((favorite) => {
-      const { id, title, rating, img, alias} = favorite;
+      const { id, title, rating, image, alias} = favorite;
       console.log('this is a favorite: ', favorite)
       return (
         <ResultCard
@@ -21,8 +21,9 @@ const FavoritesPage = ({ user }) => {
           id={id}
           title={title}
           rating={rating}
-          photo={img}
+          photo={image}
           alias={alias}
+          user={user}
         />
       )
     })

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -18,6 +18,7 @@ const LandingPage = ({ user, addFavorite, deleteFavorite, featured }) => {
         addFavorite={addFavorite}
         deleteFavorite={deleteFavorite}
         business={business}
+        displayType="featured"
       />
     )
    }

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -1,7 +1,30 @@
 import ResultCard from "../ResultCard/ResultCard";
 import "./LandingPage.css"
 
-const LandingPage = () => {
+const LandingPage = ({ user, addFavorite, deleteFavorite, featured }) => {
+  console.log('featured in Landing Page: ', featured)
+
+  const featBusinesses = featured.map(business => {
+    const { id } = business;
+    const { title, rating, img, is_closed, alias  } = business.attributes;
+    return (
+      <ResultCard
+        key={id}
+        id={id}
+        title={title}
+        rating={rating}
+        photo={img}
+        isClosed={is_closed}
+        alias={alias}
+        user={user}
+        addFavorite={addFavorite}
+        deleteFavorite={deleteFavorite}
+        business={business}
+      />
+    )
+   }
+  )
+
   return(
     <section className="landing-section">
       <div className="overview-container">
@@ -14,9 +37,7 @@ const LandingPage = () => {
       <div className="featured-container">
         <p className="featured-businesses-msg">Featured Local Businesses:</p>
           <div className="featured-cards">
-            <ResultCard />
-            <ResultCard />
-            <ResultCard />
+            {featBusinesses}
           </div>
       </div>
     </section>

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -2,8 +2,6 @@ import ResultCard from "../ResultCard/ResultCard";
 import "./LandingPage.css"
 
 const LandingPage = ({ user, addFavorite, deleteFavorite, featured }) => {
-  console.log('featured in Landing Page: ', featured)
-
   const featBusinesses = featured.map(business => {
     const { id } = business;
     const { title, rating, img, is_closed, alias  } = business.attributes;
@@ -29,9 +27,12 @@ const LandingPage = ({ user, addFavorite, deleteFavorite, featured }) => {
     <section className="landing-section">
       <div className="overview-container">
         <p>
-          Lorem ipsum dolor amet mustache knausgaard +1, blue bottle waistcoat tbh semiotics artisan synth stumptown<br/>gastropub cornhole celiac swag.
-          Brunch raclette vexillologist post-ironic glossier ennui XOXO mlkshk godard<br/>pour-over blog tumblr humblebrag.
-          Blue bottle put a bird on it twee prism biodiesel brooklyn. Blue bottle ennui tbh succulents.
+        Eat local was designed to exclusively support local businesses.  Unlike larger companies, small businesses do not have 
+        the resources or the capital to survive without sales and support.  Approximately 1 out of 5 small businesses close their 
+        doors permanently within their first year of business.  The odds of a small business failing increase more each year they are open–with a 
+        failure rate of 66% after 10 years of business.  Although running a small business is very difficult, it is near impossible without 
+        support. To continue to have diverse options to eat, drink, and shop, there needs to be an effort made to support these businesses or 
+        your favorite neighborhood spots may not be around much longer.  Please eat local!
         </p>
       </div>
       <div className="featured-container">

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -26,14 +26,14 @@ const LandingPage = ({ user, addFavorite, deleteFavorite, featured }) => {
   return(
     <section className="landing-section">
       <div className="overview-container">
-        <p>
+        <span>
         Eat local was designed to exclusively support local businesses.  Unlike larger companies, small businesses do not have 
         the resources or the capital to survive without sales and support.  Approximately 1 out of 5 small businesses close their 
         doors permanently within their first year of business.  The odds of a small business failing increase more each year they are open–with a 
         failure rate of 66% after 10 years of business.  Although running a small business is very difficult, it is near impossible without 
         support. To continue to have diverse options to eat, drink, and shop, there needs to be an effort made to support these businesses or 
         your favorite neighborhood spots may not be around much longer.  Please eat local!
-        </p>
+        </span>
       </div>
       <div className="featured-container">
         <p className="featured-businesses-msg">Featured Local Businesses:</p>

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -15,7 +15,6 @@ const Nav = ( { business, setBusiness, location, setLocation, onSearch, name,
 
   const handleClick = (event) => {
     setOpenLogin(!openLogin);
-    // console.log('openLogin in handleClick: ', openLogin)
   }
 
   useEffect(() => {
@@ -23,7 +22,6 @@ const Nav = ( { business, setBusiness, location, setLocation, onSearch, name,
       if (!ref.current || ref.current.contains(event.target) || loginRef.current.contains(event.target)) {
         return;
       }
-      // console.log('openLogin in useEffect: ', openLogin)
       setOpenLogin(false);
     };
     document.addEventListener("mousedown", listener);
@@ -50,7 +48,7 @@ const Nav = ( { business, setBusiness, location, setLocation, onSearch, name,
         />
         <div className="greeting-menu-container">
          <span className="greeting">Hello, {greeting}!</span>
-          <span className="menu"><span ref={loginRef} className="login" onClick={(event) => handleClick(event)}>Login</span> | <Link to="/favorites">Favorites</Link></span>
+          <span className="menu"><Link to="/">Home</Link> | <span ref={loginRef} className="login" onClick={(event) => handleClick(event)}>Login</span> | <Link to="/favorites">Favorites</Link></span>
         </div>
       </nav>
       {openLogin && <div className="login-container" ref={ref}>

--- a/src/components/ResultCard/ResultCard.css
+++ b/src/components/ResultCard/ResultCard.css
@@ -1,25 +1,10 @@
 .business-card {
   border: 1px solid black;
-  /* position: absolute; */
   width: 10rem;
   margin: 0.5%;
   /* height: 10rem; */
 }
 
 .business-card-image {
-  margin-top: 5rem;
   width: 10rem;
 }
-
-.result-favorite-icon {
-  /* width: 2rem; */
-}
-
-/* .favorite-icon {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin: 0.5%;
-  width: 2rem;
-  z-index: 10;
-} */

--- a/src/components/ResultCard/ResultCard.css
+++ b/src/components/ResultCard/ResultCard.css
@@ -1,10 +1,25 @@
 .business-card {
   border: 1px solid black;
+  /* position: absolute; */
   width: 10rem;
   margin: 0.5%;
   /* height: 10rem; */
 }
 
 .business-card-image {
+  margin-top: 5rem;
   width: 10rem;
 }
+
+.result-favorite-icon {
+  /* width: 2rem; */
+}
+
+/* .favorite-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 0.5%;
+  width: 2rem;
+  z-index: 10;
+} */

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -2,13 +2,22 @@ import { Link } from "react-router-dom";
 import { AiOutlineStar } from 'react-icons/ai';
 import "./ResultCard.css";
 
-const ResultCard = ({title, photo, rating, id, alias}) => {
+const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business}) => {
+  const buttonTxt = 'add to favorites';
+  
+  // logic for user.favorites and whether or not it includes current card for btn display
+
+  const handleClick = (event) => {
+    const userId = user.id;
+    addFavorite(business, userId);
+  }
+
   return (
     <article className="business-card">
       <Link to={`/results/${alias}`}><img className="business-card-image" src={photo} alt={title}></img></Link>
       <p>{title}</p>
       <p>{rating}</p>
-      <AiOutlineStar className="result-favorite-icon" />
+      {user && <button onClick={(event) => handleClick(event)}>{buttonTxt}</button>}
     </article>
   )
 }

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -2,28 +2,31 @@ import { Link } from "react-router-dom";
 import { AiOutlineStar } from 'react-icons/ai';
 import "./ResultCard.css";
 
-const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business}) => {
-  const inUserFavs = user.favorites.reduce((acc, favorite) => {
-    console.log('favorite.title in reduce: ', favorite.title)
-    if (favorite.title === title) {
-      acc = true;
-    }
-    return acc;
-  }, false)
+const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business}) => { 
+  let inUserFavs = false;
   
-  const buttonTxt = inUserFavs ? 'delete from favorites' : 'add to favorites'
-
-  const handleClick = (event) => {
-    const userId = user.id;
-    addFavorite(business, userId);
+  if (user) {
+    inUserFavs = user.favorites.reduce((acc, favorite) => {
+      if (favorite.title === title) {
+        acc = true;
+      }
+      return acc;
+    }, false)
   }
+  
+  const handleDelete = () => {
+    const currentFavorite = user.favorites.find(favorite => favorite.title === title)
+    deleteFavorite(parseInt(currentFavorite.id));
+  }
+
+  const buttonTxt = inUserFavs ? 'delete from favorites' : 'add to favorites'
 
   return (
     <article className="business-card">
       <Link to={`/results/${alias}`}><img className="business-card-image" src={photo} alt={title}></img></Link>
       <p>{title}</p>
       <p>{rating}</p>
-      {user && <button onClick={(event) => handleClick(event)}>{buttonTxt}</button>}
+      {user && <button onClick={inUserFavs ? handleDelete : () => addFavorite(business, user.id)}>{buttonTxt}</button>}
     </article>
   )
 }

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { AiOutlineStar } from 'react-icons/ai';
+// import { AiOutlineStar } from 'react-icons/ai';
 import "./ResultCard.css";
 
 const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business, displayType}) => { 

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -1,15 +1,15 @@
-import "./ResultCard.css"
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
+import { AiOutlineStar } from 'react-icons/ai';
+import "./ResultCard.css";
 
 const ResultCard = ({title, photo, rating, id, alias}) => {
   return (
-    <Link to={`/results/${alias}`}>
     <article className="business-card">
-      <img className="business-card-image" src={photo} alt={title}></img>
+      <Link to={`/results/${alias}`}><img className="business-card-image" src={photo} alt={title}></img></Link>
       <p>{title}</p>
       <p>{rating}</p>
+      <AiOutlineStar className="result-favorite-icon" />
     </article>
-    </Link>
   )
 }
 

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { AiOutlineStar } from 'react-icons/ai';
 import "./ResultCard.css";
 
-const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business}) => { 
+const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business, displayType}) => { 
   let inUserFavs = false;
   
   if (user) {
@@ -19,11 +19,22 @@ const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteF
     deleteFavorite(parseInt(currentFavorite.id));
   }
 
+  let linkText;
+
+  if (displayType === "featured") {
+    linkText = `/featured/${alias}`
+  } else if (displayType === "result") {
+    linkText = `/results/${alias}`
+  } else if (displayType === "favorite") {
+    linkText = `/favorites/${alias}`
+    // or favorites/title, whatever we end up using!
+  }
+
   const buttonTxt = inUserFavs ? 'delete from favorites' : 'add to favorites'
 
   return (
     <article className="business-card">
-      <Link to={`/results/${alias}`}><img className="business-card-image" src={photo} alt={title}></img></Link>
+      <Link to={linkText}><img className="business-card-image" src={photo} alt={title}></img></Link>
       <p>{title}</p>
       <p>{rating}</p>
       {user && <button onClick={inUserFavs ? handleDelete : () => addFavorite(business, user.id)}>{buttonTxt}</button>}

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -3,9 +3,15 @@ import { AiOutlineStar } from 'react-icons/ai';
 import "./ResultCard.css";
 
 const ResultCard = ({title, photo, rating, id, alias, user, addFavorite, deleteFavorite, business}) => {
-  const buttonTxt = 'add to favorites';
+  const inUserFavs = user.favorites.reduce((acc, favorite) => {
+    console.log('favorite.title in reduce: ', favorite.title)
+    if (favorite.title === title) {
+      acc = true;
+    }
+    return acc;
+  }, false)
   
-  // logic for user.favorites and whether or not it includes current card for btn display
+  const buttonTxt = inUserFavs ? 'delete from favorites' : 'add to favorites'
 
   const handleClick = (event) => {
     const userId = user.id;

--- a/src/components/ResultsPage/ResultsPage.js
+++ b/src/components/ResultsPage/ResultsPage.js
@@ -6,7 +6,7 @@ const ResultsPage = ({ results, user, addFavorite, deleteFavorite }) => {
   const businessCards = results.map((business) => {
     const { id } = business;
     const { title, rating, img, is_closed, alias  } = business.attributes;
-    console.log('this is img, assigned to photo: ', img)
+   
     return (
       <ResultCard
         key={id}

--- a/src/components/ResultsPage/ResultsPage.js
+++ b/src/components/ResultsPage/ResultsPage.js
@@ -2,10 +2,11 @@ import "./ResultsPage.css"
 import React from 'react'
 import ResultCard from "../ResultCard/ResultCard"
 
-const ResultsPage = ({ results }) => {
+const ResultsPage = ({ results, user, addFavorite, deleteFavorite }) => {
   const businessCards = results.map((business) => {
     const { id } = business;
     const { title, rating, img, is_closed, alias  } = business.attributes;
+    console.log('this is img, assigned to photo: ', img)
     return (
       <ResultCard
         key={id}
@@ -15,6 +16,10 @@ const ResultsPage = ({ results }) => {
         photo={img}
         isClosed={is_closed}
         alias={alias}
+        user={user}
+        addFavorite={addFavorite}
+        deleteFavorite={deleteFavorite}
+        business={business}
       />
     )
   })

--- a/src/components/ResultsPage/ResultsPage.js
+++ b/src/components/ResultsPage/ResultsPage.js
@@ -20,6 +20,7 @@ const ResultsPage = ({ results, user, addFavorite, deleteFavorite }) => {
         addFavorite={addFavorite}
         deleteFavorite={deleteFavorite}
         business={business}
+        displayType="result"
       />
     )
   })

--- a/src/components/SingleResultPage/SingleResultPage.css
+++ b/src/components/SingleResultPage/SingleResultPage.css
@@ -29,5 +29,5 @@
   top: 0;
   right: 0;
   margin: 0.5%;
-  width: 2rem;
+  /* width: 2rem; */
 }

--- a/src/components/SingleResultPage/SingleResultPage.js
+++ b/src/components/SingleResultPage/SingleResultPage.js
@@ -1,7 +1,7 @@
 import "./SingleResultPage.css";
 import GoogleMapReact from 'google-map-react';
-import {MdLocationPin} from 'react-icons/md'
-import {AiOutlineStar} from 'react-icons/ai'
+import { MdLocationPin } from 'react-icons/md';
+import { AiOutlineStar } from 'react-icons/ai';
 const apiKey = process.env.REACT_APP_GOOGLE_API_KEY
 
 const Marker = ({ text }) => <div>{text}</div>

--- a/src/components/SingleResultPage/SingleResultPage.js
+++ b/src/components/SingleResultPage/SingleResultPage.js
@@ -7,6 +7,7 @@ const apiKey = process.env.REACT_APP_GOOGLE_API_KEY
 const Marker = ({ text }) => <div>{text}</div>
 
 const SingleResultPage = ({ business }) => {
+  console.log('i am business: ', business)
   const { img, display_phone, rating, site, title, price, coordinates, display_address } = business.attributes;
   const phone = display_phone.replace(/[^\d]/g, '');
   const address = display_address.display_address.map((element) => `${element} `)


### PR DESCRIPTION
# Pull Request

## Category: [Feature] [Refactor]

## Description:
- add featured fetch display, and feature click to single page display functionality
- refactor router and result card component to handle different "types" to account for the different link hrefs
- complete favorite/unfavorite functionality for featured, results, and favorites (need to add to single pg display)
- refactored/cleaned up code where applicable

## Next Steps:
- figure out why user only updates on refresh — is this a webpack/graphQL thing, or do we need to fetch the new and updated user, and setUser(updatedUser) in our favorite/unfavorite mutation graphQL function calls?
- adding either similar btn functionality for favoriting/unfavoriting on single result pg display, or cracking that logic for the react icons (I don’t know how to use them, so I used btns, but the logic, in theory, is the same!)
- routing for favorites result card link to display a single pg result (cracked this for featured vs. results to single pg display, the logic should be the same, I just don’t remember how to router with the match object)

## Any other comments or questions:
go team!